### PR TITLE
Change directory before using script

### DIFF
--- a/presentation/exercises.tex
+++ b/presentation/exercises.tex
@@ -91,9 +91,9 @@ $ R
 \subsection*{Exercise 2 -- BLAST+ at the command line}
 
 \begin{lstlisting}[language=bash]
+$ cd ../ex2_blast
 $ script
 Script started, output file is typescript
-$ cd ../ex2_blast
 $ blastp -num_alignments 1 -num_descriptions 1 -query query.fasta -db dbA
 $ exit
 exit
@@ -102,9 +102,11 @@ Script done, output file is typescript
 
 \begin{lstlisting}[language=bash]
 $ cat typescript
-Script started on Fri May  9 10:45:12 2014
-lpritc@lpmacpro:$ cd ../ex2_blast
-[...]
+Script started on Wed Dec 10 11:48:06 2014
+[username@hostname ex2_blast]$ blastp -num_alignments 1 -num_descriptions 1 -query query.fasta -db dbA
+BLASTP 2.2.30+
+
+...
 \end{lstlisting}
 
 \section*{Part 2: BLAST}

--- a/presentation/sections/subsection_goldenrule2exercise.tex
+++ b/presentation/sections/subsection_goldenrule2exercise.tex
@@ -25,9 +25,11 @@
   \frametitle{Exercise 2}
   \framesubtitle{Starting \texttt{script}}    
   \begin{itemize}
-    \item Start recording your actions by entering \texttt{script} at the command line      
+    \item Change directory to where Exercise 2 data is located
+    \item Start recording your actions by using \texttt{script}
   \end{itemize}
 \begin{lstlisting}[language=bash]
+$ cd ../ex2_blast
 $ script
 Script started, output file is typescript
 \end{lstlisting}    
@@ -41,13 +43,12 @@ Script started, output file is typescript
   \frametitle{Exercise 2}
   \framesubtitle{Running \texttt{BLAST}}
   \begin{itemize}
-    \item Change directory to the \texttt{ex2\_blast} directory
     \item Run \texttt{BLAST} with the appropriate database
     \item Exit \texttt{script}
   \end{itemize}
 \begin{lstlisting}[language=bash]
-$ cd ../ex2_blast
 $ blastp -num_alignments 1 -num_descriptions 1 -query query.fasta -db dbA
+...
 $ exit
 exit
 Script done, output file is typescript
@@ -61,11 +62,18 @@ Script done, output file is typescript
   \begin{itemize}
     \item You can view the \texttt{typescript} file with \texttt{cat}
   \end{itemize}
-\begin{lstlisting}[language=bash]
+\begin{lstlisting}[language=]
 $ cat typescript
-Script started on Fri May  9 10:45:12 2014
-lpritc@lpmacpro:$ cd ../ex2_blast
-[...]
+Script started on Wed Dec 10 11:48:06 2014
+[username@hostname ex2_blast]$ blastp -num_alignments 1 -num_descriptions 1 -query query.fasta -db dbA
+BLASTP 2.2.30+
+
+
+Reference: Stephen F. Altschul, Thomas L. Madden, Alejandro A.
+Schaffer, Jinghui Zhang, Zheng Zhang, Webb Miller, and David J.
+Lipman (1997), "Gapped BLAST and PSI-BLAST: a new generation of
+protein database search programs", Nucleic Acids Res. 25:3389-3402.
+...
 \end{lstlisting}    
 \end{frame}
 


### PR DESCRIPTION
This way upon exiting script the class are still in the `ex2_blast` directory, ready for the next exercise.

Previously exiting script returned them to `ex1_expression`, which caused a certain amount of confusion.

(I didn't change this earlier because we'd already printed the handouts)
